### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/src/Result/input_form.py
+++ b/src/Result/input_form.py
@@ -70,7 +70,7 @@ def listdatacreator(lsoftitile):
             if idx==0:
                 temp["headline"]=item1
             else:
-                templist.append("http://dx.doi.org/"+item1)
+                templist.append("https://doi.org/"+item1)
         temp["sameAs"]=templist
         flist.append(temp)
     return flist


### PR DESCRIPTION

Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new DOI links.

Cheers!